### PR TITLE
Test out the migration using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+go:
+- 1.8
+
+sudo: false # Run in a container
+
+# Travis thinks only github is a thing, get pulls to work for everyone else
+addons:
+  ssh_known_hosts: bitbucket.org
+
+install: true # Skip
+script: ./scripts/migrate.sh

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+# Attempt migrating kubernetes from godep to deps
+set -xeuo pipefail
+
+# Install dep
+go get -u github.com/golang/dep/cmd/dep
+
+# Clone k8s, ignoring "no building Go files"
+go get -d k8s.io/kubernetes || true
+
+# Migrate to dep
+cd $GOPATH/src/k8s.io/kubernetes
+dep init -v
+
+# Will it blend?
+make


### PR DESCRIPTION
This fails right now because of references to pkgs in vendor (e.g. k8s.io/subpkg) that symlink to staging, which dep totally ignores.

But at least the import part is passing now, so that's a thing... 😀 